### PR TITLE
Allow to pass a custom function to be called for dispatching actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Name                  | Description
 `theme`               | _Same as in LogMonitor's package_ Either a string referring to one of the themes provided by [redux-devtools-themes](https://github.com/gaearon/redux-devtools-themes) (feel free to contribute!) or a custom object of the same format. Optional. By default, set to [`'nicinabox'`](https://github.com/gaearon/redux-devtools-themes/blob/master/src/nicinabox.js).
 `initEmpty`           | When `true`, the dispatcher is empty. By default, set to `false`, the dispatcher contains : `{ "type": "" }`.
 `actionCreators`      | Either a array of action creators or an object containing action creators. When defined, a selector appears to choose the action creator you want to fire, you can fill up the arguments and dispatch the action.
+`dispatchFn`          | Function to be called for dispatching actions. By default it is using component's `this.context.store.dispatch`. 
 
 ### Contributing
 

--- a/src/Dispatcher.js
+++ b/src/Dispatcher.js
@@ -52,6 +52,7 @@ export default class Dispatcher extends Component {
       PropTypes.object,
       PropTypes.array,
     ]),
+    dispatchFn: PropTypes.func,
     theme: PropTypes.oneOfType([
       PropTypes.object,
       PropTypes.string,
@@ -116,7 +117,7 @@ export default class Dispatcher extends Component {
         actionCreator = new Function('return ' + this.refs.action.textContent);
       }
 
-      this.context.store.dispatch(actionCreator(...argsToInject));
+      (this.props.dispatchFn || this.context.store.dispatch)(actionCreator(...argsToInject));
 
       this.setState({error: null});
     } catch(e) {


### PR DESCRIPTION
Redux `store` can be passed directly to devtools without having it in `context` like so `<DevTools store={store} />`, it will not work for this monitor. A solution would be to specify the dispatch function explicitly like `<Dispatcher dispatchFn={store.dispatch} />`, which is introduced in this PR.
