### PR TITLE
Import PropTypes from prop-types package

### DIFF
--- a/examples/counter/src/components/Counter.js
+++ b/examples/counter/src/components/Counter.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 export default class Counter extends Component {
   static propTypes = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-devtools-dispatch",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Dispatch your actions manually to test if your app reacts well",
   "main": "lib/index.js",
   "scripts": {
@@ -36,7 +36,7 @@
     "webpack": "^1.11.0"
   },
   "peerDependencies": {
-    "react": ">=0.14.0",
+    "react": ">=0.14.9",
     "redux-devtools": "^3.0.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "dependencies": {
     "get-params": "^0.1.2",
+    "prop-types": "^15.5.10",
     "redux-devtools-themes": "^1.0.0"
   }
 }

--- a/src/Dispatcher.js
+++ b/src/Dispatcher.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import getParams from 'get-params';
 import * as themes from 'redux-devtools-themes';
 


### PR DESCRIPTION
Resolves a deprecation warning due to `PropTypes` being removed from the main `react` package in the next upcoming major release.

https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.proptypes